### PR TITLE
DM-29119: Make test_csc.py more robust

### DIFF
--- a/doc/version_history.rst
+++ b/doc/version_history.rst
@@ -6,6 +6,19 @@
 Version History
 ###############
 
+v1.5.1
+======
+
+* Make test_csc.py more robust by changing assert_angle_in_range to test angle <= max_angle instead of <.
+  This avoids a race condition.
+
+Requires:
+
+* ts_salobj 6
+* ts_simactuators 2
+* ts_idl
+* IDL file for ATDome from ts_xml 7.2
+
 v1.5.0
 ======
 

--- a/tests/test_csc.py
+++ b/tests/test_csc.py
@@ -286,9 +286,13 @@ class CscTestCase(salobj.BaseCscTestCase, asynctest.TestCase):
         """Assert that an angle is in the given range.
 
         All arguments must be in range [0, 360) (and this is checked).
+        If min_angle > max_angle then the test is::
 
-        If max_angle < min_angle then the check is:
-        min_angle <= angle < 360 or 0 <= angle < max_angle
+            min_angle <= angle < 360 or 0 <= angle <= max_angle
+
+        otherwise the test is the obvious::
+
+            min_angle <= angle <= max_angle
 
         Parameters
         ----------
@@ -312,12 +316,12 @@ class CscTestCase(salobj.BaseCscTestCase, asynctest.TestCase):
                     f"Argument {argname} = {argvalue} not in range [0, 360)"
                 )
         if min_angle > max_angle:
-            if not (min_angle <= angle < 360 or 0 <= angle < max_angle):
+            if not (min_angle <= angle < 360 or 0 <= angle <= max_angle):
                 raise AssertionError(
                     f"angle {angle} not in range [{min_angle}, 360) or [0, {max_angle}]"
                 )
         else:
-            if not (min_angle <= angle < max_angle):
+            if not (min_angle <= angle <= max_angle):
                 raise AssertionError(
                     f"angle {angle} not in range [{min_angle}, {max_angle}]"
                 )


### PR DESCRIPTION
Update assert_angle_in_range to test for inclusive range
(as it always should have done) and clarify its documentation.