### PR TITLE
Fix version history for 1.5.1

### DIFF
--- a/doc/version_history.rst
+++ b/doc/version_history.rst
@@ -6,13 +6,24 @@
 Version History
 ###############
 
+v1.5.1
+======
+
+* Make test_csc.py more robust by changing assert_angle_in_range to test angle <= max_angle instead of <.
+  This avoids a race condition.
+
+Requires:
+
+* ts_salobj 6.3
+* ts_simactuators 2
+* ts_idl
+* IDL file for ATDome from ts_xml 8
+
 v1.5.0
 ======
 
 * Store the CSC configuration schema in code.
   This requires ts_salobj 6.3.
-* Make test_csc.py more robust by changing assert_angle_in_range to test angle <= max_angle instead of <.
-  This avoids a race condition.
 
 Requires:
 


### PR DESCRIPTION
I found the 1.5.0 tag after all; not sure why it didn't show up in the first place